### PR TITLE
Move Plexus to hard dependencies

### DIFF
--- a/PlexusStatusRaidDebuff.toc
+++ b/PlexusStatusRaidDebuff.toc
@@ -12,7 +12,8 @@
 ## Author: Azelkeeber(KR-Tirion),Toadkiller,Stassart,Doadin
 ## Version: @project-version@
 ## Grid Author: Pastamancer & Maia
-## OptionalDeps: LibBabble-Zone-3.0, LibBabble-Boss-3.0, AceLocale-3.0, Grid, Plexus
+## OptionalDeps: LibBabble-Zone-3.0, LibBabble-Boss-3.0, AceLocale-3.0
+## Dependencies: Plexus
 ## X-Category: UnitFrame
 ## X-Curse-Project-ID: 42578
 


### PR DESCRIPTION
The Addon was forked and renamed, therefore we can depend on Plexus now.